### PR TITLE
[t142166][ADD] _get_inventory_fields_write

### DIFF
--- a/stock_quant_analytic/models/stock_quant.py
+++ b/stock_quant_analytic/models/stock_quant.py
@@ -6,7 +6,7 @@
 # See LICENSE file for full licensing details.
 ##############################################################################
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockQuant(models.Model):
@@ -37,4 +37,10 @@ class StockQuant(models.Model):
             res["analytic_account_id"] = self.analytic_account_id.id
         if self.analytic_tag_ids:
             res["analytic_tag_ids"] = [(6, 0, self.analytic_tag_ids.ids)]
+        return res
+
+    @api.model
+    def _get_inventory_fields_write(self):
+        res = super()._get_inventory_fields_write()
+        res.extend(["analytic_account_id", "analytic_tag_ids"])
         return res


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=142166">[t142166] [NETA15] [DEV] Migration v15 - BUG: Modules that Add Fields to the Inventory Adjustment (stock.quant) Views Need to Add them to the Allowed Fields</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>stock_quant_analytic</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->